### PR TITLE
Fix styling & some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,18 @@
 SDRam module of any size is required
 
 # Bootrom
-You need to add Bootrom files for both WonderSwan and WonderSwan Color to the WonderSwan Folder and name it:
-boot.rom -> WonderSwan bootrom
+You need to add Bootrom files for both WonderSwan and WonderSwan Color to the WonderSwan Folder and name it:  
+boot.rom -> WonderSwan bootrom  
 boot1.rom -> WonderSwan Color bootrom
 
 Checksums for valid Bootroms:
 
-WonderSwan (4Kbyte)
-SHA-1: 4015BCACEA76BB0B5BBDB13C5358F7E1ABB986A1
+WonderSwan (4Kbyte)  
+SHA-1: 4015BCACEA76BB0B5BBDB13C5358F7E1ABB986A1  
 MD5: 54B915694731CC22E07D3FB8A00EE2DB
 
-WonderSwan Color (8Kbyte)
-SHA-1: C5AD0B8AF45D762662A69F50B64161B9C8919EFB
+WonderSwan Color (8Kbyte)  
+SHA-1: C5AD0B8AF45D762662A69F50B64161B9C8919EFB  
 MD5: 880893BD5A7D53FFF826BD76A83D566E
 
 # Status
@@ -34,24 +34,24 @@ Not working games:
 - Flickerblend: 2 or 3 frames blending
 
 # Refresh Rate
-WonderSwan uses a refresh rateof 75.4Hz
+WonderSwan uses a refresh rate of 75.4Hz.  
 You can choose to run the core at either 60Hz(compatibility mode) or 75.4Hz.
 
 For 60Hz mode you can either:
 - live with tearing
 - Buffer video: triple buffering for clean image, but increases lag
 
-For 75,4Hz mode:
-Please use "Sync core to Video -> On", to help the core sync back to video after reset, savestate, pause, fastfoward.
+For 75.4Hz mode:
+Please use "Sync core to Video -> On" to help the core sync back to video after reset, savestate, pause, fastfoward.
 
 # Rotation
-WonderSwan has built in rotation. 
-With option autorotate the image will rotate according to requests from the game itself.
+WonderSwan has built in rotation.  
+With option autorotate the image will rotate according to requests from the game itself.  
 Or you can set a fixed rotation.
 
 # Savestates
-Core provides 4 slots to save and restore the state. 
-Those can be saved to SDCard or reside only in memory for temporary use(OSD Option). 
+Core provides 4 slots to save and restore the state.  
+Those can be saved to SDCard or reside only in memory for temporary use(OSD Option).  
 Usage with either Keyboard, Gamepad mappable button or OSD.
 
 Keyboard Hotkeys for save states:
@@ -64,9 +64,9 @@ Gamepad:
 - Savestatebutton+Start+Up loads from the selected slot
 
 # Rewind
-To use rewind, turn on the OSD Option "Rewind Capture" and map the rewind button.
-You may have to restart the game for the function to work properly.
-Attention: Rewind capture will slow down your game by about 0.5% and may lead to light audio stutter.
+To use rewind, turn on the OSD Option "Rewind Capture" and map the rewind button.  
+You may have to restart the game for the function to work properly.  
+Attention: Rewind capture will slow down your game by about 0.5% and may lead to light audio stutter.  
 Rewind capture is not compatible to "Pause when OSD is open", so pause is disabled when Rewind capture is on.
 
 # Missing features


### PR DESCRIPTION
Two spaces force a line break, which was the intended styling, i think. Makes the explanation for bootroms way more readable and less prone to mixing up boot and boot1.