### PR TITLE
Serial support over SNAC and HPS UART

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Not working games:
 
 # Features
 - Savestates
+- WonderSwan link cable serial port (9600/38400 baud and 192000-baud SoC test mode)
 - FastForward - speed up game by factor 2.5, hold button or tap Button to toggle
 - CPU Turbo - give games additional computation power
 - Rewind: go back up to 20 seconds in time
@@ -49,6 +50,29 @@ WonderSwan has built in rotation.
 With option autorotate the image will rotate according to requests from the game itself.  
 Or you can set a fixed rotation.
 
+# Link Cable
+The emulated EXT-port UART is connected to the MiSTer User port:
+
+
+
+Set **Miscellaneous > Serial Port** to **On** before starting linked play. The
+option is disabled by default and releases the serial outputs when it is off.
+Once enabled, **Serial Route** selects one of two connections:
+
+- **Internal** routes conventional, idle-high serial through the HPS
+  `UART_RXD`/`UART_TXD` interface. This is the default route. Select an HPS
+  UART speed of 9600, 38400, or 192000 to match the rate selected by the
+  running WonderSwan software.
+- **SNAC** routes the WonderSwan's inverted physical signals through
+  - `USER_IN[2]` (`USR2`) is the WonderSwan receive signal.
+  - `USER_OUT[1]` (`D-/TX`) is the WonderSwan transmit signal.
+
+The User-port output is open drain. Use an adapter intended for the MiSTer User
+port with the required 3.3 V buffering/pull-ups and crossed RX/TX wiring; do not
+connect an original console EXT port directly to the FPGA pins. Fast Forward and
+CPU Turbo are automatically suspended while the emulated serial port is enabled
+so that link timing remains at the native WonderSwan clock rate.
+
 # Savestates
 Core provides 4 slots to save and restore the state.  
 Those can be saved to SDCard or reside only in memory for temporary use(OSD Option).  
@@ -70,5 +94,4 @@ Attention: Rewind capture will slow down your game by about 0.5% and may lead to
 Rewind capture is not compatible to "Pause when OSD is open", so pause is disabled when Rewind capture is on.
 
 # Missing features
-- All Multiplayer/Internet features
 - Internal EEPROM (Name, Birthdate) not saved to SDCard

--- a/WonderSwan.sv
+++ b/WonderSwan.sv
@@ -179,9 +179,20 @@ module emu
 
 assign ADC_BUS  = 'Z;
 assign VGA_F1 = 0;
-assign USER_OUT = '1;
+wire ws_serial_tx;
+wire link_cable = status[47];
+wire serial_route_snac = status[48];
+wire ws_serial_rx = !link_cable ? 1'b0 :
+                    serial_route_snac ? USER_IN[2] : ~UART_RXD;
 
-assign {UART_RTS, UART_TXD, UART_DTR} = 0;
+// WonderSwan link cable SNAC route on the User port:
+//   USER 2 = receive from WonderSwan, USER 1 = transmit to WonderSwan.
+assign USER_OUT = {5'b11111, (link_cable && serial_route_snac) ? ws_serial_tx : 1'b1, 1'b1};
+
+// The HPS UART uses conventional idle-high UART polarity, so invert the
+// WonderSwan EXT-port signal at the Internal route boundary.
+assign UART_TXD = (link_cable && !serial_route_snac) ? ~ws_serial_tx : 1'b1;
+assign {UART_RTS, UART_DTR} = 0;
 
 assign {SD_SCK, SD_MOSI, SD_CS} = 'Z;
 
@@ -207,7 +218,7 @@ assign AUDIO_MIX = status[8:7];
 
 `include "build_id.v" 
 localparam CONF_STR = {
-	"WonderSwan;SS3E000000:100000;",
+	"WonderSwan;SS3E000000:100000,UART9600:38400:192000;",
 	"FS1,WSCWS PC2,Load ROM;",
 	"-;",
 	"O[40:39],System,Auto,WonderSwan,SwanColor,PocketChallengeV2;",
@@ -244,6 +255,8 @@ localparam CONF_STR = {
 	"P2,Miscellaneous;",
 	"P2-;",
 	"P2O[9],CPU Turbo,Off,On;",
+	"P2O[47],Serial Port,Off,On;",
+	"d1P2O[48],Serial Route,Internal,SNAC;",
 	"P2O[26],Pause when OSD is open,Off,On;",
 	"P2O[27],Rewind Capture,Off,On;",
 	"-;",
@@ -331,7 +344,7 @@ hps_io #(.CONF_STR(CONF_STR), .WIDE(1)) hps_io
 	.ioctl_index(filetype),
 
 	.status(status),
-	.status_menumask(cart_ready),
+	.status_menumask({14'd0, link_cable, cart_ready}),
 	.status_in({status[63:39], ss_slot, status[36:30], 2'b00, status[27:0]}),
 	.status_set(statusUpdate),
 
@@ -553,6 +566,11 @@ SwanTop SwanTop (
 	.KeyStart         (joystick_0[6]),
 	.KeyA             (joystick_0[4]),
 	.KeyB             (joystick_0[5]),
+
+	// EXT-port serial link
+	.link_enabled     (link_cable),
+	.serial_rx        (ws_serial_rx),
+	.serial_tx        (ws_serial_tx),
 	
 	// RTC
 	.RTC_timestampNew(RTC_time[32]),

--- a/files.qip
+++ b/files.qip
@@ -10,7 +10,7 @@ set_global_assignment -name VHDL_FILE rtl/bus_savestates.vhd
 set_global_assignment -name VHDL_FILE rtl/reg_savestates.vhd
 set_global_assignment -name VHDL_FILE rtl/statemanager.vhd
 set_global_assignment -name VHDL_FILE rtl/savestates.vhd
-set_global_assignment -name VHDL_FILE rtl/dummyregs.vhd
+set_global_assignment -name VHDL_FILE rtl/serial.vhd
 set_global_assignment -name VHDL_FILE rtl/sound_module1.vhd
 set_global_assignment -name VHDL_FILE rtl/sound_module2.vhd
 set_global_assignment -name VHDL_FILE rtl/sound_module3.vhd

--- a/rtl/IRQ.vhd
+++ b/rtl/IRQ.vhd
@@ -22,6 +22,8 @@ entity IRQ is
       IRQ_VBlankTmr        : in  std_logic;
       IRQ_VBlank           : in  std_logic;
       IRQ_HBlankTmr        : in  std_logic;
+      IRQ_SerialSend       : in  std_logic;
+      IRQ_SerialReceive    : in  std_logic;
       
       RegBus_Din           : in  std_logic_vector(BUS_buswidth-1 downto 0);
       RegBus_Adr           : in  std_logic_vector(BUS_busadr-1 downto 0);
@@ -95,6 +97,8 @@ begin
          elsif (ce = '1') then
          
             -- set
+            if (IRQ_SerialSend    = '1' and INT_ENABLE(0) = '1') then INT_STATUS(0) <= '1'; end if;
+            if (IRQ_SerialReceive = '1' and INT_ENABLE(3) = '1') then INT_STATUS(3) <= '1'; end if;
             if (IRQ_LineComp  = '1' and INT_ENABLE(4) = '1') then INT_STATUS(4) <= '1'; end if;
             if (IRQ_VBlankTmr = '1' and INT_ENABLE(5) = '1') then INT_STATUS(5) <= '1'; end if;
             if (IRQ_VBlank    = '1' and INT_ENABLE(6) = '1') then INT_STATUS(6) <= '1'; end if;
@@ -111,7 +115,9 @@ begin
             
             -- clear
             if (INT_ACK_written = '1') then
+               if (RegBus_Din(0) = '1') then INT_STATUS(0) <= '0'; end if;
                if (RegBus_Din(1) = '1') then INT_STATUS(1) <= '0'; end if;
+               if (RegBus_Din(3) = '1') then INT_STATUS(3) <= '0'; end if;
                if (RegBus_Din(4) = '1') then INT_STATUS(4) <= '0'; end if;
                if (RegBus_Din(5) = '1') then INT_STATUS(5) <= '0'; end if;
                if (RegBus_Din(6) = '1') then INT_STATUS(6) <= '0'; end if;

--- a/rtl/cpu.vhd
+++ b/rtl/cpu.vhd
@@ -45,6 +45,7 @@ entity cpu is
       RegBus_Adr        : out std_logic_vector(BUS_busadr-1 downto 0) := (others => '0');
       RegBus_wren       : out std_logic := '0';
       RegBus_rden       : out std_logic := '0';
+      RegBus_word       : out std_logic := '0';
       RegBus_Dout       : in  std_logic_vector(BUS_buswidth-1 downto 0);
          
       -- savestates        
@@ -510,6 +511,7 @@ begin
             prefetchAllow  <= '1';
             RegBus_wren    <= '0';
             RegBus_rden    <= '0';
+            RegBus_word    <= '0';
          end if;
          
          --if (testpcsum(63) = '1' and testcmd(31) = '1') then
@@ -574,6 +576,7 @@ begin
             
             RegBus_wren     <= '0';
             RegBus_rden     <= '0';
+            RegBus_word     <= '0';
             
          elsif (ce_4x = '1') then
          
@@ -2332,6 +2335,9 @@ begin
                            
                         when OP_OPOUT =>
                            memFirst <= '0';
+                           if (opsize = 2) then
+                              RegBus_word <= '1';
+                           end if;
                            if (opsize = 1 or memFirst = '1') then
                               RegBus_Din   <= std_logic_vector(source2Val(7 downto 0));
                               RegBus_Adr   <= std_logic_vector(source1Val(7 downto 0));

--- a/rtl/reg_savestates.vhd
+++ b/rtl/reg_savestates.vhd
@@ -15,6 +15,7 @@ package pReg_savestates is
    constant REG_SAVESTATE_CPU4        : savestate_type := (  3,   31,      0,        1, x"00000000F0020000"); -- F_DS
    
    constant REG_SAVESTATE_IRQ         : savestate_type := (  5,    7,      0,        1, x"0000000000000000");
+   constant REG_SAVESTATE_UART        : savestate_type := (  6,   63,      0,        1, x"0000000000000000");
    
    constant REG_SAVESTATE_GPU         : savestate_type := (  7,   15,      0,        1, x"0000000000009EFF");
    

--- a/rtl/serial.vhd
+++ b/rtl/serial.vhd
@@ -1,0 +1,325 @@
+library IEEE;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+
+use work.pRegisterBus.all;
+use work.pBus_savestates.all;
+use work.pReg_savestates.all;
+
+-- WonderSwan EXT-port UART.
+--
+-- The external signals use inverted UART polarity: the line is low while
+-- idle, a start bit is high, data bits are inverted, and the stop bit is low.
+-- The core clock enable is the native 3.072 MHz WonderSwan clock, giving
+-- exact divisors of 320 clocks/bit at 9600 baud, 80 clocks/bit at 38400,
+-- and 16 clocks/bit in the SoC's 192000-baud UART test mode.
+entity ws_serial is
+   port
+   (
+      clk               : in  std_logic;
+      ce                : in  std_logic;
+      reset             : in  std_logic;
+
+      serial_rx         : in  std_logic;
+      serial_tx         : out std_logic;
+      active            : out std_logic;
+
+      IRQ_SerialSend    : out std_logic;
+      IRQ_SerialReceive : out std_logic;
+
+      RegBus_Din        : in  std_logic_vector(BUS_buswidth-1 downto 0);
+      RegBus_Adr        : in  std_logic_vector(BUS_busadr-1 downto 0);
+      RegBus_wren       : in  std_logic;
+      RegBus_rden       : in  std_logic;
+      RegBus_word       : in  std_logic;
+      RegBus_Dout       : out std_logic_vector(BUS_buswidth-1 downto 0);
+
+      SSBUS_Din         : in  std_logic_vector(SSBUS_buswidth-1 downto 0);
+      SSBUS_Adr         : in  std_logic_vector(SSBUS_busadr-1 downto 0);
+      SSBUS_wren        : in  std_logic;
+      SSBUS_rst         : in  std_logic;
+      SSBUS_Dout        : out std_logic_vector(SSBUS_buswidth-1 downto 0)
+   );
+end entity;
+
+architecture arch of ws_serial is
+
+   constant TX_IDLE        : std_logic_vector(2 downto 0) := "000";
+   constant TX_WAIT_ENABLE : std_logic_vector(2 downto 0) := "001";
+   constant TX_START       : std_logic_vector(2 downto 0) := "010";
+   constant TX_DATA        : std_logic_vector(2 downto 0) := "011";
+   constant TX_STOP        : std_logic_vector(2 downto 0) := "100";
+
+   constant RX_IDLE        : std_logic_vector(1 downto 0) := "00";
+   constant RX_START       : std_logic_vector(1 downto 0) := "01";
+   constant RX_BITS        : std_logic_vector(1 downto 0) := "10";
+   constant RX_STOP        : std_logic_vector(1 downto 0) := "11";
+
+   signal control_enable    : std_logic := '0';
+   signal control_highspeed : std_logic := '0';
+   signal uart_test         : std_logic := '0';
+
+   signal baud_reload      : unsigned(8 downto 0);
+   signal baud_half_reload : unsigned(8 downto 0);
+
+   signal tx_state        : std_logic_vector(2 downto 0) := TX_IDLE;
+   signal tx_shift        : std_logic_vector(7 downto 0) := (others => '0');
+   signal tx_bit_index    : unsigned(2 downto 0) := (others => '0');
+   signal tx_baud_counter : unsigned(8 downto 0) := (others => '0');
+   signal tx_busy         : std_logic := '0';
+   signal tx_line         : std_logic := '0';
+
+   signal rx_state        : std_logic_vector(1 downto 0) := RX_IDLE;
+   signal rx_shift        : std_logic_vector(7 downto 0) := (others => '0');
+   signal rx_data         : std_logic_vector(7 downto 0) := (others => '0');
+   signal rx_bit_index    : unsigned(2 downto 0) := (others => '0');
+   signal rx_baud_counter : unsigned(8 downto 0) := (others => '0');
+   signal rx_full         : std_logic := '0';
+   signal rx_overrun      : std_logic := '0';
+
+   signal rx_meta         : std_logic := '0';
+   signal rx_sync         : std_logic := '0';
+
+   signal SS_UART      : std_logic_vector(REG_SAVESTATE_UART.upper downto REG_SAVESTATE_UART.lower);
+   signal SS_UART_BACK : std_logic_vector(REG_SAVESTATE_UART.upper downto REG_SAVESTATE_UART.lower);
+
+begin
+
+   baud_reload <= to_unsigned(15, baud_reload'length) when uart_test = '1' else
+                  to_unsigned(79, baud_reload'length) when control_highspeed = '1' else
+                  to_unsigned(319, baud_reload'length);
+
+   baud_half_reload <= to_unsigned(7, baud_half_reload'length) when uart_test = '1' else
+                       to_unsigned(39, baud_half_reload'length) when control_highspeed = '1' else
+                       to_unsigned(159, baud_half_reload'length);
+
+   serial_tx <= tx_line;
+   active    <= control_enable;
+
+   IRQ_SerialSend    <= control_enable and not tx_busy;
+   IRQ_SerialReceive <= control_enable and rx_full;
+
+   process (all)
+   begin
+      RegBus_Dout <= (others => '0');
+
+      if RegBus_Adr = x"A3" then
+         RegBus_Dout(3) <= uart_test;
+      elsif RegBus_Adr = x"B1" then
+         RegBus_Dout <= rx_data;
+      elsif RegBus_Adr = x"B3" then
+         RegBus_Dout(7) <= control_enable;
+         RegBus_Dout(6) <= control_highspeed;
+         RegBus_Dout(2) <= not tx_busy;
+         RegBus_Dout(1) <= rx_overrun;
+         RegBus_Dout(0) <= rx_full;
+      end if;
+   end process;
+
+   iSS_UART : entity work.eReg_SS
+   generic map (REG_SAVESTATE_UART)
+   port map
+   (
+      clk, SSBUS_Din, SSBUS_Adr, SSBUS_wren, SSBUS_rst,
+      SSBUS_Dout, SS_UART_BACK, SS_UART
+   );
+
+   SS_UART_BACK(0)            <= control_enable;
+   SS_UART_BACK(1)            <= control_highspeed;
+   SS_UART_BACK(2)            <= rx_full;
+   SS_UART_BACK(3)            <= rx_overrun;
+   SS_UART_BACK(4)            <= tx_busy;
+   SS_UART_BACK(5)            <= tx_line;
+   SS_UART_BACK(8 downto 6)   <= tx_state;
+   SS_UART_BACK(11 downto 9)  <= std_logic_vector(tx_bit_index);
+   SS_UART_BACK(20 downto 12) <= std_logic_vector(tx_baud_counter);
+   SS_UART_BACK(28 downto 21) <= tx_shift;
+   SS_UART_BACK(30 downto 29) <= rx_state;
+   SS_UART_BACK(33 downto 31) <= std_logic_vector(rx_bit_index);
+   SS_UART_BACK(42 downto 34) <= std_logic_vector(rx_baud_counter);
+   SS_UART_BACK(50 downto 43) <= rx_shift;
+   SS_UART_BACK(58 downto 51) <= rx_data;
+   SS_UART_BACK(59)           <= rx_meta;
+   SS_UART_BACK(60)           <= rx_sync;
+   SS_UART_BACK(61)           <= uart_test;
+   SS_UART_BACK(63 downto 62) <= (others => '0');
+
+   process (clk)
+   begin
+      if rising_edge(clk) then
+         if reset = '1' then
+            control_enable    <= SS_UART(0);
+            control_highspeed <= SS_UART(1);
+            rx_full           <= SS_UART(2);
+            rx_overrun        <= SS_UART(3);
+            tx_busy           <= SS_UART(4);
+            tx_line           <= SS_UART(5);
+            tx_state          <= SS_UART(8 downto 6);
+            tx_bit_index      <= unsigned(SS_UART(11 downto 9));
+            tx_baud_counter   <= unsigned(SS_UART(20 downto 12));
+            tx_shift          <= SS_UART(28 downto 21);
+            rx_state          <= SS_UART(30 downto 29);
+            rx_bit_index      <= unsigned(SS_UART(33 downto 31));
+            rx_baud_counter   <= unsigned(SS_UART(42 downto 34));
+            rx_shift          <= SS_UART(50 downto 43);
+            rx_data           <= SS_UART(58 downto 51);
+            rx_meta           <= SS_UART(59);
+            rx_sync           <= SS_UART(60);
+            uart_test         <= SS_UART(61);
+         else
+            -- Synchronize the asynchronous EXT-port input into clk.
+            rx_meta <= serial_rx;
+            rx_sync <= rx_meta;
+
+            -- $B3: enable, speed, and write-one-to-clear overrun.
+            if RegBus_wren = '1' and RegBus_Adr = x"B3" then
+               control_enable    <= RegBus_Din(7);
+               control_highspeed <= RegBus_Din(6);
+               if RegBus_Din(5) = '1' then
+                  rx_overrun <= '0';
+               end if;
+            end if;
+
+            -- $A3 bit 3 enables the SoC UART test clock. Hardware ignores
+            -- this register when it is reached as the high byte of a word
+            -- write to $A2, so accept byte writes only.
+            if RegBus_wren = '1' and RegBus_word = '0' and RegBus_Adr = x"A3" then
+               uart_test <= RegBus_Din(3);
+            end if;
+
+            -- Reading $B1 consumes the one-byte receive buffer.
+            if RegBus_rden = '1' and RegBus_Adr = x"B1" then
+               rx_full <= '0';
+            end if;
+
+            -- Writes while the one-byte transmit buffer is full are ignored.
+            if RegBus_wren = '1' and RegBus_Adr = x"B1" and tx_busy = '0' then
+               tx_shift <= RegBus_Din;
+               tx_busy  <= '1';
+               tx_state <= TX_WAIT_ENABLE;
+            end if;
+
+            if ce = '1' then
+               -- Transmitter. When disabled, retain a queued byte but return
+               -- the external line to its low (idle) state.
+               if control_enable = '0' then
+                  tx_line <= '0';
+                  if tx_busy = '1' then
+                     tx_state <= TX_WAIT_ENABLE;
+                  else
+                     tx_state <= TX_IDLE;
+                  end if;
+               else
+                  case tx_state is
+                     when TX_IDLE =>
+                        tx_line <= '0';
+
+                     when TX_WAIT_ENABLE =>
+                        tx_line         <= '1'; -- inverted start bit
+                        tx_state        <= TX_START;
+                        tx_baud_counter <= baud_reload;
+
+                     when TX_START =>
+                        if tx_baud_counter = 0 then
+                           tx_line      <= not tx_shift(0);
+                           tx_bit_index <= (others => '0');
+                           tx_state     <= TX_DATA;
+                           tx_baud_counter <= baud_reload;
+                        else
+                           tx_baud_counter <= tx_baud_counter - 1;
+                        end if;
+
+                     when TX_DATA =>
+                        if tx_baud_counter = 0 then
+                           if tx_bit_index = 7 then
+                              tx_line  <= '0'; -- inverted stop bit
+                              tx_state <= TX_STOP;
+                           else
+                              tx_bit_index <= tx_bit_index + 1;
+                              tx_line      <= not tx_shift(to_integer(tx_bit_index) + 1);
+                           end if;
+                           tx_baud_counter <= baud_reload;
+                        else
+                           tx_baud_counter <= tx_baud_counter - 1;
+                        end if;
+
+                     when TX_STOP =>
+                        if tx_baud_counter = 0 then
+                           tx_line  <= '0';
+                           tx_busy  <= '0';
+                           tx_state <= TX_IDLE;
+                        else
+                           tx_baud_counter <= tx_baud_counter - 1;
+                        end if;
+
+                     when others =>
+                        tx_line  <= '0';
+                        tx_busy  <= '0';
+                        tx_state <= TX_IDLE;
+                  end case;
+               end if;
+
+               -- Receiver. Start and data are sampled in the center of each
+               -- bit cell. A bad (high) inverted stop bit drops the frame.
+               if control_enable = '0' then
+                  rx_state        <= RX_IDLE;
+                  rx_baud_counter <= (others => '0');
+               else
+                  case rx_state is
+                     when RX_IDLE =>
+                        if rx_sync = '1' then -- inverted start bit
+                           rx_state <= RX_START;
+                           rx_baud_counter <= baud_half_reload;
+                        end if;
+
+                     when RX_START =>
+                        if rx_baud_counter = 0 then
+                           if rx_sync = '1' then
+                              rx_bit_index <= (others => '0');
+                              rx_state     <= RX_BITS;
+                              rx_baud_counter <= baud_reload;
+                           else
+                              rx_state <= RX_IDLE;
+                           end if;
+                        else
+                           rx_baud_counter <= rx_baud_counter - 1;
+                        end if;
+
+                     when RX_BITS =>
+                        if rx_baud_counter = 0 then
+                           rx_shift(to_integer(rx_bit_index)) <= not rx_sync;
+                           if rx_bit_index = 7 then
+                              rx_state <= RX_STOP;
+                           else
+                              rx_bit_index <= rx_bit_index + 1;
+                           end if;
+                           rx_baud_counter <= baud_reload;
+                        else
+                           rx_baud_counter <= rx_baud_counter - 1;
+                        end if;
+
+                     when RX_STOP =>
+                        if rx_baud_counter = 0 then
+                           if rx_sync = '0' then -- valid inverted stop bit
+                              if rx_full = '1' then
+                                 rx_overrun <= '1';
+                              else
+                                 rx_data <= rx_shift;
+                                 rx_full <= '1';
+                              end if;
+                           end if;
+                           rx_state <= RX_IDLE;
+                        else
+                           rx_baud_counter <= rx_baud_counter - 1;
+                        end if;
+
+                     when others =>
+                        rx_state <= RX_IDLE;
+                  end case;
+               end if;
+            end if;
+         end if;
+      end if;
+   end process;
+
+end architecture;

--- a/rtl/swanTop.vhd
+++ b/rtl/swanTop.vhd
@@ -72,6 +72,11 @@ entity SwanTop is
       KeyStart                   : in  std_logic;
       KeyA                       : in  std_logic;
       KeyB                       : in  std_logic;
+
+      -- EXT-port serial link
+      link_enabled               : in  std_logic;
+      serial_rx                  : in  std_logic;
+      serial_tx                  : out std_logic;
       
       -- RTC
       RTC_timestampNew           : in  std_logic;                     -- new current timestamp from system
@@ -133,6 +138,7 @@ architecture arch of SwanTop is
    signal RegBus_Adr             : std_logic_vector(BUS_busadr-1 downto 0) := (others => '0');
    signal RegBus_wren            : std_logic;
    signal RegBus_rden            : std_logic;
+   signal RegBus_word            : std_logic;
    signal RegBus_rst             : std_logic;
    signal RegBus_Dout            : std_logic_vector(BUS_buswidth-1 downto 0);
    signal RegBus_Dout_mapped     : std_logic_vector(BUS_buswidth-1 downto 0);
@@ -142,6 +148,7 @@ architecture arch of SwanTop is
    signal CPU_RegBus_Adr         : std_logic_vector(BUS_busadr-1 downto 0);
    signal CPU_RegBus_wren        : std_logic;
    signal CPU_RegBus_rden        : std_logic;
+   signal CPU_RegBus_word        : std_logic;
    
    type t_reg_wired_or is array(0 to 7) of std_logic_vector(7 downto 0);
    signal reg_wired_or : t_reg_wired_or;
@@ -188,6 +195,13 @@ architecture arch of SwanTop is
    signal IRQ_VBlankTmr          : std_logic;
    signal IRQ_VBlank             : std_logic;
    signal IRQ_HBlankTmr          : std_logic;
+   signal IRQ_SerialSend         : std_logic;
+   signal IRQ_SerialReceive      : std_logic;
+
+   -- serial
+   signal serial_active          : std_logic;
+   signal serial_link_active     : std_logic;
+   signal cpu_turbo              : std_logic;
    
    -- GPU
    signal GPU_addr               : std_logic_vector(15 downto 0);
@@ -214,7 +228,7 @@ architecture arch of SwanTop is
    signal system_idle            : std_logic;
    signal savestate_slow         : std_logic;
    
-   type t_ss_wired_or is array(0 to 5) of std_logic_vector(63 downto 0);
+   type t_ss_wired_or is array(0 to 6) of std_logic_vector(63 downto 0);
    signal ss_wired_or : t_ss_wired_or;
    
    signal savestate_savestate    : std_logic; 
@@ -322,7 +336,7 @@ begin
                      ce_counter <= (others => '0');
                   end if;
                   if (ce_counter = 1 or ce_counter = 4 or ce_counter = 7 or ce_counter = 10) then
-                     if (fastforward = '1' and savestate_slow = '0' and rewind_active = '0' and cpuCanSpeedup = '1') then
+                     if (fastforward = '1' and serial_link_active = '0' and savestate_slow = '0' and rewind_active = '0' and cpuCanSpeedup = '1') then
                         clockState <= FASTFORWARDMODE;
                      end if;
                   end if;
@@ -337,7 +351,7 @@ begin
                   end if;
 
                when FASTFORWARDMODE =>
-                  if (fastforward = '0' or savestate_slow = '1' or rewind_active = '1' or cpuCanSpeedup = '0' or EXTRAM_read = '1' or EXTRAM_write = '1') then
+                  if (fastforward = '0' or serial_link_active = '1' or savestate_slow = '1' or rewind_active = '1' or cpuCanSpeedup = '0' or EXTRAM_read = '1' or EXTRAM_write = '1') then
                      clockState <= NORMAL;
                      if (ce_counter >= 2) then
                         ce_counter <= ce_counter - 1;
@@ -404,21 +418,36 @@ begin
    RegBus_Adr  <= SSMEM_Addr(7 downto 0)      when sleep_savestate = '1' else CPU_RegBus_Adr;
    RegBus_wren <= SSMEM_WrEn(0)               when sleep_savestate = '1' else CPU_RegBus_wren;
    RegBus_rden <= '0'                         when sleep_savestate = '1' else CPU_RegBus_rden;
+   RegBus_word <= '0'                         when sleep_savestate = '1' else CPU_RegBus_word;
    
    SSMEM_ReadData_REG <= RegBus_Dout;
    
-   idummyregs : entity work.dummyregs
+   iserial : entity work.ws_serial
    port map
    (
-      clk          => clk,
-      ce           => ce,
-      reset        => reset,
-                                 
-      RegBus_Din   => RegBus_Din,
-      RegBus_Adr   => RegBus_Adr,
-      RegBus_wren  => RegBus_wren,
-      RegBus_rst   => RegBus_rst,
-      RegBus_Dout  => reg_wired_or(0)
+      clk               => clk,
+      ce                => ce,
+      reset             => reset,
+
+      serial_rx         => serial_rx,
+      serial_tx         => serial_tx,
+      active            => serial_active,
+
+      IRQ_SerialSend    => IRQ_SerialSend,
+      IRQ_SerialReceive => IRQ_SerialReceive,
+
+      RegBus_Din        => RegBus_Din,
+      RegBus_Adr        => RegBus_Adr,
+      RegBus_wren       => RegBus_wren,
+      RegBus_rden       => RegBus_rden,
+      RegBus_word       => RegBus_word,
+      RegBus_Dout       => reg_wired_or(0),
+
+      SSBUS_Din         => SSBUS_Din,
+      SSBUS_Adr         => SSBUS_Adr,
+      SSBUS_wren        => SSBUS_wren,
+      SSBUS_rst         => SSBUS_rst,
+      SSBUS_Dout        => ss_wired_or(6)
    );
    
    -- Memory Mux
@@ -506,7 +535,7 @@ begin
       ce                => ce_cpu,   
       ce_4x             => ce_4x,
       reset             => reset,
-      turbo             => turbo,
+      turbo             => cpu_turbo,
       --SLOWTIMING        => is_simu,
       SLOWTIMING        => '0',
    
@@ -539,6 +568,7 @@ begin
       RegBus_Adr        => CPU_RegBus_Adr, 
       RegBus_wren       => CPU_RegBus_wren,
       RegBus_rden       => CPU_RegBus_rden,
+      RegBus_word       => CPU_RegBus_word,
       RegBus_Dout       => RegBus_Dout_mapped,
 
       sleep_savestate   => sleep_savestate,
@@ -611,6 +641,8 @@ begin
       IRQ_VBlankTmr        => IRQ_VBlankTmr,
       IRQ_VBlank           => IRQ_VBlank   ,
       IRQ_HBlankTmr        => IRQ_HBlankTmr,
+      IRQ_SerialSend       => IRQ_SerialSend,
+      IRQ_SerialReceive    => IRQ_SerialReceive,
       
 -- synthesis translate_off
       export_irq           => export_irq,         
@@ -628,6 +660,10 @@ begin
       SSBUS_rst            => SSBUS_rst, 
       SSBUS_Dout           => ss_wired_or(3)
    );
+
+   -- A physical peer always runs at the native clock rate.
+   serial_link_active <= serial_active and link_enabled;
+   cpu_turbo          <= turbo and not serial_link_active;
    
    -- joypad
    ijoypad: entity work.joypad


### PR DESCRIPTION
Allows link cable games to work between two MiSTers

Internal serial routing option allows you to go online with the MobileWonderGate cart using the [wonderfence](https://github.com/kconger/wonderfence) mobile adapter emulation software.